### PR TITLE
When two (or more) elo ratings are equal, order by games played (desc)

### DIFF
--- a/app/models/elo_rating.rb
+++ b/app/models/elo_rating.rb
@@ -7,7 +7,7 @@ class EloRating < ActiveRecord::Base
   end
 
   def self.by_rating
-    order('elo_ratings.rating DESC')
+    order('elo_ratings.rating DESC, elo_ratings.games_played DESC')
   end
 
 end


### PR DESCRIPTION
Currently on DooPlex Pool, the second-place and third-place players both have the same elo rating but the third player has played more games than the second player. 

In this situation, the player who has the played the most games should be placed ahead of the aforementioned player. We have more confidence in the elo rating of player who have played the most games so they should be placed first.
