### PR TITLE
Fix navbar and tweak space around icon-user

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,11 +26,11 @@
             <span class="icon-bar"></span>
           </a>
           <%= link_to t('application.name'), root_path, :class => "brand" %>
-          <div class="container nav-collapse">
+          <div class="collapse nav-collapse">
             <% if user_logged_in? %>
               <ul class="nav pull-right">
                 <li class="dropdown">
-                  <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="icon-user"></i><%= current_user.name %><b class="caret"></b></a>
+                  <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="icon-user"></i> <%= current_user.name %><b class="caret"></b></a>
                   <ul class="dropdown-menu">
                     <li><%= link_to t('settings.show.title'), setting_path %></li>
                     <li><%= link_to t('sessions.logout'), logout_path %></li>


### PR DESCRIPTION
.nav-collapse should also have .collapse class. This fixes a bug where, on smaller viewports, the user dropdown menu doesn't expand the parent container as it should.
