### PR TITLE
Allow admins to delete championships

### DIFF
--- a/app/controllers/tournaments/championships_controller.rb
+++ b/app/controllers/tournaments/championships_controller.rb
@@ -1,19 +1,23 @@
 class Tournaments::ChampionshipsController < ApplicationController
-  before_action :authenticate_user!, only: [:create, :update, :join]
+  before_action :authenticate_user!, only: [:create, :update, :join, :destroy]
   before_action :find_tournament
   before_action :find_championship, except: [:create]
-  before_action :require_owner!, only: [:create, :update]
+  before_action :require_owner!, only: [:create, :update, :destroy]
 
   layout 'tournament_title', only: [:show]
 
   def show
-    @players = @championship.players.includes(:user).order('users.name ASC')
-    @player = @tournament.players.active.find_by(user_id: current_user)
-    @championship_player = @players.find_by(user_id: current_user)
-    @matches = @championship.matches.incomplete.allocated
-    @next_match = @matches.with_player(@player).first
-    if @next_match
-      @next_opponent = @next_match.player1 == @player ? @next_match.player2 : @next_match.player1
+    if @championship
+      @players = @championship.players.includes(:user).order('users.name ASC')
+      @player = @tournament.players.active.find_by(user_id: current_user)
+      @championship_player = @players.find_by(user_id: current_user)
+      @matches = @championship.matches.incomplete.allocated
+      @next_match = @matches.with_player(@player).first
+      if @next_match
+        @next_opponent = @next_match.player1 == @player ? @next_match.player2 : @next_match.player1
+      end
+    else
+      redirect_to tournament_path(@tournament)
     end
   end
 
@@ -65,6 +69,11 @@ class Tournaments::ChampionshipsController < ApplicationController
       end
     end
     redirect_back fallback_location: tournament_championship_path(@tournament)
+  end
+
+  def destroy
+    @championship.destroy
+    redirect_to edit_tournament_path(@tournament)
   end
 
   private

--- a/app/views/tournaments/championships/show.html.erb
+++ b/app/views/tournaments/championships/show.html.erb
@@ -3,10 +3,17 @@
 <div class="championships">
   <% if @championship.started? %>
     <p><%= raw t('.started', time: time_tag(@championship.started_at)) %></p>
+
+    <% if @tournament.owner == current_user %>
+      <p><%= link_to t('.delete'), tournament_championship_path(@tournament), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %></p>
+    <% end %>
   <% else %>
     <p><%= t '.not_started' %></p>
     <% if @tournament.owner == current_user %>
-      <p><%= link_to t('.start'), tournament_championship_path(@tournament), :class => 'btn btn-primary', :method => :put %></p>
+      <p>
+        <%= link_to t('.start'), tournament_championship_path(@tournament), :class => 'btn btn-primary', :method => :put %>
+        <%= link_to t('.delete'), tournament_championship_path(@tournament), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
+      </p>
     <% end %>
     <% if @player && !@championship_player %>
       <div class="alert alert-info">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,7 @@ en:
         started: The championship started on %{time}.
         not_started: The championship will be started by the tournament owner.
         start: Start Championship
+        delete: Delete Championship
         champions: Champions
         bracket: Bracket
         match: Your next match is with %{name}.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
       resources :games, :only => [:index, :destroy]
       resources :players, :only => [:index, :update, :destroy]
       resources :invite_requests, :only => [:index, :create, :update]
-      resource :championship do
+      resource :championship, :except => [:index] do
         member do
           get :bracket
           post :join


### PR DESCRIPTION
People forget to join championships and complain. Allow admins to remove the current championship so they can create a new one.